### PR TITLE
Set all impacts to 0.5

### DIFF
--- a/controls/eks-cis-3.2.10.rb
+++ b/controls/eks-cis-3.2.10.rb
@@ -67,8 +67,8 @@ string.
     --RotateCertificate=true
     ```
   "
-  impact 0.7
-  tag severity: 'high'
+  impact 0.5
+  tag severity: 'medium'
   tag gtitle: nil
   tag gid: nil
   tag rid: nil

--- a/controls/eks-cis-3.2.9.rb
+++ b/controls/eks-cis-3.2.9.rb
@@ -116,8 +116,8 @@ configuration changes
     systemctl status kubelet -l
     ```
   "
-  impact 0.7
-  tag severity: 'high'
+  impact 0.5
+  tag severity: 'medium'
   tag gtitle: nil
   tag gid: nil
   tag rid: nil

--- a/controls/eks-cis-4.5.1.rb
+++ b/controls/eks-cis-4.5.1.rb
@@ -8,8 +8,8 @@ to ensure that only approved images are deployed in the cluster."
   desc  'check', "Review the pod definitions in your cluster and verify that
 image provenance is configured as appropriate."
   desc  'fix', 'Follow the Kubernetes documentation and setup image provenance.'
-  impact 0.7
-  tag severity: 'high'
+  impact 0.5
+  tag severity: 'medium'
   tag gtitle: nil
   tag gid: nil
   tag rid: nil

--- a/inspec.yml
+++ b/inspec.yml
@@ -5,7 +5,7 @@ copyright: The MITRE Corporation, 2021
 copyright_email: .
 license: Apache-2.0
 summary: InSpec Profile for AWS EKS CIS Benchmark v1.0.1 tests that require direct SSH access to the nodes
-version: 0.1.0
+version: 0.1.1
 
 depends:
   - name: inspec-k8s-node


### PR DESCRIPTION
CIS benchmarks don't really have a High, Medium, Low vulnerability severity context. Their Levels 1, 2 refer to complexity of implementation of a configuration setting, not the severity of the vulnerability to a system that doesn't implement the setting in question. Our early cis-to-inspec stub-out code inadvertantly mapped these levels to medium (0.5) and high (0.7).

This branch/PR corrects this by setting all impacts to 0.5 and severity tag to medium. (just "down the middle / even for all")